### PR TITLE
Do not force script-security to generate potentially partial all whitelist

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/permissivescriptsecurity/PermissiveWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/permissivescriptsecurity/PermissiveWhitelist.java
@@ -55,8 +55,6 @@ public class PermissiveWhitelist extends Whitelist {
 
     /*package*/ static final Logger LOGGER = Logger.getLogger(PermissiveWhitelist.class.getName());
 
-    private static final Whitelist ALL = Whitelist.all();
-
     public enum Mode {
         DISABLED() {
             @Override
@@ -77,7 +75,7 @@ public class PermissiveWhitelist extends Whitelist {
 
                 rl.lock();
                 try {
-                    Boolean otherwiseWhitelisted = check.apply(ALL);
+                    Boolean otherwiseWhitelisted = check.apply(Whitelist.all());
                     if (!otherwiseWhitelisted) {
                         RejectedAccessException raj = reject.get();
                         LOGGER.log(Level.INFO, "Unsecure signature found: " + raj.getSignature(), raj);


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-59145

I have to admit I do not have a slightness idea why this problem manifests in this specific way: together with prometheus:2.0.6, pipeline script and some other UI elements are not rendered or are rendered incorrectly.

However, I have narrowed the changes causing the problem to calling `Whitelist.all()` too soon during plugins' initialization and verified than rectifying that fixes the problem. Doing so was clearly a mistake and based on the implementation I would expect it to have various ill effects, but not this.

CCing @jglick, just FYI.