### PR TITLE
Upgrade plugin parent to 4.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.40</version>
+        <version>4.40</version>
+        <relativePath/>
     </parent>
     <artifactId>permissive-script-security</artifactId>
     <version>0.8-SNAPSHOT</version>
@@ -14,54 +15,47 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.level>8</java.level>
-        <jenkins.version>2.107.3</jenkins.version>
+        <jenkins.version>2.303.3</jenkins.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+        <dependency>
+            <groupId>io.jenkins.tools.bom</groupId>
+            <artifactId>bom-2.303.x</artifactId>
+            <version>1409.v7659b_c072f18</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.58</version>
         </dependency>
 
         <!-- pipeline integration -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.25</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
-            <version>2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
             <scope>test</scope>
-        </dependency>
-
-        <!-- upper bound -->
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>symbol-annotation</artifactId>
-            <version>1.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/permissivescriptsecurity/PermissiveWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/permissivescriptsecurity/PermissiveWhitelist.java
@@ -23,6 +23,8 @@
  */
 package org.jenkinsci.plugins.permissivescriptsecurity;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
@@ -30,8 +32,6 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
 @Restricted(NoExternalUse.class)
 @Extension(ordinal = Double.MIN_VALUE) // Run if no other whitelist permitted the signature.
 public class PermissiveWhitelist extends Whitelist {
-    /*package*/ static @Nonnull Mode MODE = Mode.getConfigured(
+    /*package*/ static @NonNull Mode MODE = Mode.getConfigured(
             System.getProperty("permissive-script-security.enabled", "false")
     );
 
@@ -106,49 +106,49 @@ public class PermissiveWhitelist extends Whitelist {
         }
     }
 
-    public boolean permitsMethod(@Nonnull Method method, @Nonnull Object receiver, @Nonnull Object[] args) {
+    public boolean permitsMethod(@NonNull Method method, @NonNull Object receiver, @NonNull Object[] args) {
         return MODE.act(
                 w -> w.permitsMethod(method, receiver, args),
                 () -> StaticWhitelist.rejectMethod(method)
         );
     }
 
-    public boolean permitsConstructor(@Nonnull Constructor<?> constructor, @Nonnull Object[] args) {
+    public boolean permitsConstructor(@NonNull Constructor<?> constructor, @NonNull Object[] args) {
         return MODE.act(
                 w -> w.permitsConstructor(constructor, args),
                 () -> StaticWhitelist.rejectNew(constructor)
         );
     }
 
-    public boolean permitsStaticMethod(@Nonnull Method method, @Nonnull Object[] args) {
+    public boolean permitsStaticMethod(@NonNull Method method, @NonNull Object[] args) {
         return MODE.act(
                 w -> w.permitsStaticMethod(method, args),
                 () -> StaticWhitelist.rejectStaticMethod(method)
         );
     }
 
-    public boolean permitsFieldGet(@Nonnull Field field, @Nonnull Object receiver) {
+    public boolean permitsFieldGet(@NonNull Field field, @NonNull Object receiver) {
         return MODE.act(
                 w -> w.permitsFieldGet(field, receiver),
                 () -> StaticWhitelist.rejectField(field)
         );
     }
 
-    public boolean permitsFieldSet(@Nonnull Field field, @Nonnull Object receiver, @CheckForNull Object value) {
+    public boolean permitsFieldSet(@NonNull Field field, @NonNull Object receiver, @CheckForNull Object value) {
         return MODE.act(
                 w -> w.permitsFieldSet(field, receiver, value),
                 () -> StaticWhitelist.rejectField(field)
         );
     }
 
-    public boolean permitsStaticFieldGet(@Nonnull Field field) {
+    public boolean permitsStaticFieldGet(@NonNull Field field) {
         return MODE.act(
                 w -> w.permitsStaticFieldGet(field),
                 () -> StaticWhitelist.rejectStaticField(field)
         );
     }
 
-    public boolean permitsStaticFieldSet(@Nonnull Field field, @CheckForNull Object value) {
+    public boolean permitsStaticFieldSet(@NonNull Field field, @CheckForNull Object value) {
         return MODE.act(
                 w -> w.permitsStaticFieldSet(field, value),
                 () -> StaticWhitelist.rejectStaticField(field)

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Do not install unless you know what you are doing. Turns on permissive mode of Script Security Plugin. Problematic signatures will be logged but access will not be rejected.
+</div>


### PR DESCRIPTION
These changes bring the plugin up to the latest tooling, which allows testing against Java 17.

- Upgrade parent to [4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40)
- Drop unnecessary java.level property
- Bump jenkins.version to 2.303.3
- Rely on plugins bom for version resolution
- Transition from javax.annotations to SpotBugs
- Introduces required src/main/resources/index.jelly

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
